### PR TITLE
Fix inline query with config sources

### DIFF
--- a/src/ragql/cli.py
+++ b/src/ragql/cli.py
@@ -161,9 +161,9 @@ def main() -> None:
 
     # If they passed an inline question, answer and exit
     # (you could detect more than one and loop, but this matches your old style)
-    if args.command is None and len(args.sources) > 1:
+    if args.command is None and len(sources) > 1:
         # no command, two positional args: sources + question
-        question = args.sources[1]
+        question = sources[1]
         logging.info(f"Inline query: {question}")
         print(rq.query(question))
         return

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -1,0 +1,35 @@
+import sys
+from ragql import cli
+from ragql.config import Settings
+
+
+def test_inline_query_from_config(monkeypatch, tmp_path, capsys):
+    p1 = tmp_path / "a"
+    p2 = tmp_path / "b"
+    p1.mkdir()
+    p2.mkdir()
+    cfg = Settings(db_path=tmp_path / "db.sqlite")
+    cfg.allowed_folders = [str(p1), str(p2)]
+
+    record = {}
+
+    class DummyRQ:
+        def __init__(self, root, cfg_in):
+            record["init"] = root
+
+        def build(self):
+            pass
+
+        def query(self, q):
+            record["question"] = q
+            return "ANSWER"
+
+    monkeypatch.setattr(cli.Settings, "load", classmethod(lambda cls: cfg))
+    monkeypatch.setattr(cli, "RagQL", DummyRQ)
+    monkeypatch.setattr(sys, "argv", ["ragql"])
+
+    cli.main()
+
+    out, _ = capsys.readouterr()
+    assert "ANSWER" in out
+    assert record["question"] == str(p2)


### PR DESCRIPTION
## Summary
- fix inline query logic to reference the computed `sources` list
- add regression test for inline query when config supplies folders
- format the new test file with black

## Testing
- `ruff check src/ragql/cli.py test/test_cli.py`
- `black --check src/ragql/cli.py test/test_cli.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68463e2118488321a7210b31d74fe1f5